### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -18,6 +18,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/chrillebile/.dotfiles/security/code-scanning/4](https://github.com/chrillebile/.dotfiles/security/code-scanning/4)

In general, fix this by explicitly adding a `permissions` block that grants only the scopes required by the workflow, either at the top workflow level (applies to all jobs) or per job. Since both `lint` and `build` only need to read the repository contents, the least-privilege starting point is `permissions: contents: read`.

The single best fix here, without changing functionality, is to add a workflow-level `permissions` block with `contents: read` just after the `on:` section and before `jobs:` in `.github/workflows/setup.yml`. This will apply to both `lint` and `build` and satisfy CodeQL’s requirement while keeping the token read-only. No other scopes (like `pull-requests: write` or `issues: write`) are obviously needed from the shown code, so we avoid granting them.

Concretely:
- Edit `.github/workflows/setup.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (ending at line 20) and the `jobs:` block (starting at line 22).
- No imports or additional definitions are needed; this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
